### PR TITLE
Eliminate use of deprecated Fixnum class

### DIFF
--- a/lib/smartystreets.rb
+++ b/lib/smartystreets.rb
@@ -84,7 +84,7 @@ module SmartyStreets
   end
 
   def self.street_address_api_url
-    defined?(@@api_url) ? @@api_url : 'https://api.smartystreets.com'
+    defined?(@@api_url) ? @@api_url : 'https://us-street.api.smartystreets.com'
   end
 
   # Set the Zipcode API url.

--- a/lib/smartystreets/api_error.rb
+++ b/lib/smartystreets/api_error.rb
@@ -17,7 +17,7 @@ module SmartyStreets
 
 
     def self.from_code(code)
-      check_type(code, Fixnum)
+      check_type(code, Integer)
       case code
       when BAD_INPUT then new(code, 'Bad input. Required Fields missing from input, are malformed, or are too numerous.')
       when UNAUTHORIZED then new(code, 'Unauthorized. Authentication failure; invalid credentials')

--- a/lib/smartystreets/base_json_object.rb
+++ b/lib/smartystreets/base_json_object.rb
@@ -27,22 +27,22 @@ module SmartyStreets
       check_type(hash[key], String)
     end
 
-    def get_optional_fixnum(hash, key)
-      hash[key] != nil ? check_type(hash[key], Fixnum) : nil
+    def get_optional_integer(hash, key)
+      hash[key] != nil ? check_type(hash[key], Integer) : nil
     end
 
-    def get_required_fixnum(hash, key)
-      check_argument(hash[key] != nil, -> { "#{key} was nil and should be a fixnum"})
-      check_type(hash[key], Fixnum)
+    def get_required_integer(hash, key)
+      check_argument(hash[key] != nil, -> { "#{key} was nil and should be an integer"})
+      check_type(hash[key], Integer)
     end
 
     def get_optional_number(hash, key)
-      hash[key] != nil ? check_type(hash[key], Float, Fixnum) : nil
+      hash[key] != nil ? check_type(hash[key], Float, Integer) : nil
     end
 
     def get_required_number(hash, key)
       check_argument(hash[key] != nil)
-      check_type(hash[key], Float, Fixnum)
+      check_type(hash[key], Float, Integer)
     end
 
     def get_optional_float(hash, key)

--- a/lib/smartystreets/street_address_request.rb
+++ b/lib/smartystreets/street_address_request.rb
@@ -32,7 +32,7 @@ module SmartyStreets
       @zipcode = get_optional_string(hash, :zipcode)
       @lastline = get_optional_string(hash, :lastline)
       @urbanization = get_optional_string(hash, :urbanization)
-      @candidates = get_optional_fixnum(hash, :candidates)
+      @candidates = get_optional_integer(hash, :candidates)
     end
 
     def to_json(*a)

--- a/lib/smartystreets/street_address_response.rb
+++ b/lib/smartystreets/street_address_response.rb
@@ -24,8 +24,8 @@ module SmartyStreets
     def initialize(hash)
       super(hash)
       @input_id = get_optional_string(hash, :input_id)
-      @input_index = get_optional_fixnum(hash, :input_index)
-      @candidate_index = get_optional_fixnum(hash, :candidate_index)
+      @input_index = get_optional_integer(hash, :input_index)
+      @candidate_index = get_optional_integer(hash, :candidate_index)
       @addressee = get_optional_string(hash, :addressee)
       @delivery_line_1 = get_optional_string(hash, :delivery_line_1)
       @delivery_line_2 = get_optional_string(hash, :delivery_line_2)
@@ -121,7 +121,7 @@ module SmartyStreets
         @longitude = get_optional_number(hash, :longitude)
         @precision = get_optional_string(hash, :precision)
         @time_zone = get_optional_string(hash, :time_zone)
-        @utc_offset = get_optional_fixnum(hash, :utc_offset)
+        @utc_offset = get_optional_integer(hash, :utc_offset)
         @dst = get_optional_boolean(hash, :dst)
       end
     end


### PR DESCRIPTION
Fix deprecation warning, and merge in latest changes from RatioClothing/smartystreets_ruby.